### PR TITLE
Use Guzzle 3.* because it contains it's own CA certs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.3.0",
         "symfony/http-foundation": "2.*",
-        "guzzle/guzzle": "2.*"
+        "guzzle/guzzle": "3.*"
     },
     "require-dev": {
         "mockery/mockery": "0.7.*"


### PR DESCRIPTION
Guzzle 3.0.0+ comes with its CA certificates for curl.
Also there's no documentation for Guzzle 2.x available on the interwebs. You have to either look at the code or compile the docs for that legacy version yourself from an old version of the [guzzle/guzzle-docs](https://github.com/guzzle/guzzle-docs/) repo.

Also it should be safe replacing "guzzle/guzzle": "2._" in composer.json with "guzzle/guzzle": "3._" as Socialite is not making use of any dropped (ex.: service descriptions in XML) or changed features as far as I could see and as far as the single included test goes.
