### PR TITLE
Update Guzzle and improve getCurrentUrl method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.3.0",
         "symfony/http-foundation": "2.*",
-        "guzzle/guzzle": "2.*"
+        "guzzle/guzzle": "3.*"
     },
     "require-dev": {
         "mockery/mockery": "0.7.*"

--- a/src/Illuminate/Socialite/OAuthTwo/OAuthTwoProvider.php
+++ b/src/Illuminate/Socialite/OAuthTwo/OAuthTwoProvider.php
@@ -360,7 +360,7 @@ abstract class OAuthTwoProvider {
 	 */
 	protected function getCurrentUrl(Request $r)
 	{
-		return $r->getScheme().'://'.$r->getHttpHost().$r->getPathInfo();
+		return $r->getSchemeAndHttpHost() . $r->getBaseUrl() . $r->getPathInfo();
 	}
 
 	/**


### PR DESCRIPTION
This pull request improves the getCurrentUrl method, so that sites that don't have URL rewriting turned on or don't exist at the base URL for a given domain also work correctly.
