### PR TITLE
Improve getCurrentUrl method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.3.0",
         "symfony/http-foundation": "2.*",
-        "guzzle/guzzle": "2.*"
+        "guzzle/guzzle": "3.*"
     },
     "require-dev": {
         "mockery/mockery": "0.7.*"

--- a/src/Illuminate/Socialite/OAuthTwo/OAuthTwoProvider.php
+++ b/src/Illuminate/Socialite/OAuthTwo/OAuthTwoProvider.php
@@ -360,7 +360,7 @@ abstract class OAuthTwoProvider {
 	 */
 	protected function getCurrentUrl(Request $r)
 	{
-		return $r->getScheme().'://'.$r->getHttpHost().$r->getPathInfo();
+		return $r->getSchemeAndHttpHost() . $r->getBaseUrl() . $r->getPathInfo();
 	}
 
 	/**


### PR DESCRIPTION
This pull request changes the getCurrentUrl() method in the OAuthTwoProvider class so that it works regardless of whether the application is installed at the root of a domain (e.g. http://example.com/) or in a subdirectory (http://example.com/myapp).
